### PR TITLE
Ticket6748: Remove excessive sample changer logging

### DIFF
--- a/sampleChangerApp/Db/sampleChanger.db
+++ b/sampleChangerApp/Db/sampleChanger.db
@@ -52,8 +52,7 @@ record(stringout, "$(P)POSN:SP") {
 
 record(sseq, "$(P)POSN:SP:RBV") {
     field(DESC, "Get the posn from the lookup")
-	field(SCAN, ".1 second")
-	field(DOL1,"$(MOT_SET_POINT)POSN:SP:RBV CA")
+	field(DOL1,"$(MOT_SET_POINT)POSN:SP:RBV CP")
 	field(LNK1,"$(P)POSN:SP PP")
 }
 

--- a/sampleChangerApp/src/converter.cpp
+++ b/sampleChangerApp/src/converter.cpp
@@ -68,7 +68,7 @@ void converter::loadRackDefs(const char* fname)
 {
     TiXmlDocument doc(fname);
     if (!doc.LoadFile()) {
-        errlogPrintf("sampleChanger: Unable to open rack defs file \"%s\"\n", fname);
+        errlogPrintf("sampleChanger: Unable to open rack defs file \"%s\": %s\n", fname, doc.ErrorDesc());
         return;
     }
 


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/6748

To test:
* Run up the sans sample changer on master e.g. `%PYTHON3% run_tests.py -t samplechanger -a`
* Check the logs and see lots of messages
* Do the same on this branch and see less messages