### PR TITLE
Ticket 6736: Expose errors to a PV

### DIFF
--- a/sampleChangerApp/Db/sampleChanger.db
+++ b/sampleChangerApp/Db/sampleChanger.db
@@ -72,3 +72,10 @@ record(waveform, "$(P)AVAILABLE_IN_SLOT") {
 	field(FLNK,"$(P)RECALC")
 }
 
+record(waveform, "$(P)ERRORS") {
+    field(SCAN, "I/O Intr")
+	field(DTYP,"asynOctetRead")
+	field(FTVL,"CHAR")
+	field(NELM,"8000")
+	field(INP,"@asyn($(LOOKUP),0,0)ERRORS")
+}

--- a/sampleChangerApp/src/converter.cpp
+++ b/sampleChangerApp/src/converter.cpp
@@ -20,7 +20,7 @@ converter::converter(int i, const std::vector<Rack>& racks, const std::vector<Sl
 }
 
 void converter::printError(const char* format, ...) {
-    char buff[100];
+    char buff[256];
     va_list argptr;
     va_start(argptr, format);
     vsnprintf(buff, sizeof(buff), format, argptr);
@@ -78,7 +78,7 @@ void converter::loadRackDefs(const char* fname)
 {
     TiXmlDocument doc(fname);
     if (!doc.LoadFile()) {
-        printError("sampleChanger: Unable to open rack defs file \"%s\": %s\n", fname, doc.ErrorDesc());
+        printError("sampleChanger: Unable to open rack defs file \"%s\". Error on line %i: %s\n\n", fname, doc.ErrorRow(), doc.ErrorDesc());
         return;
     }
 

--- a/sampleChangerApp/src/converter.h
+++ b/sampleChangerApp/src/converter.h
@@ -5,6 +5,7 @@
 #include <list>
 #include <string>
 #include <algorithm>
+#include <numeric>
 
 #define TIXML_USE_STL 
 #include "tinyxml.h"
@@ -71,9 +72,10 @@ public:
 
     const std::vector<Slot>& slots() const { return m_slots; }
     const std::vector<Rack>& racks() const { return m_racks; }
+    const std::string errors() {return std::accumulate(m_errors.begin(), m_errors.end(), std::string(""));};
 
 private:
-
+    std::vector<std::string> m_errors;
     std::vector<Slot> m_slots;
     std::vector<Rack> m_racks;
     std::vector<SlotPositions> m_positions_for_each_slot;
@@ -91,6 +93,7 @@ private:
     void loadRackDefs(const char* fname);
     void loadSlotDetails(const char* fname);
     int createLookup(FILE* fpOut);
+    void printError(const char* format, ...);
 };
 
 #endif /* CONVERTER_H */

--- a/sampleChangerApp/src/sampleChanger.h
+++ b/sampleChangerApp/src/sampleChanger.h
@@ -17,8 +17,10 @@ private:
     std::string m_fileName;
     std::string m_selectedSlot;
     int m_dims;
+    std::map <int, std::string> current_errors;
 
     int P_recalc; // string
+    int P_errors; // string
     int P_set_slot; // string
     int P_get_slot; // string
     int P_slot_from_pos; // string
@@ -32,11 +34,13 @@ private:
 #define NUM_MSP_PARAMS (&LAST_MSP_PARAM - &FIRST_MSP_PARAM + 1)
 
 #define P_recalcString        "RECALC"
+#define P_errorsString    "ERRORS"
 #define P_set_slotString    "SET_SLOT"
 #define P_get_slotString    "GET_SLOT"
 #define P_slot_from_posString    "SLOT_FROM_POS"
 #define P_set_posnString    "SET_POSN"
 #define P_get_available_slotsString    "AVAILABLE_SLOTS"
 #define P_get_available_in_selected_slotsString    "AVAILABLE_IN_SLOT"
+
 
 #endif /* SAMPLECHANGER_H */


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/6736

To test:
* Modify the xml in `settings/sans_sample_changer` to be in error, e.g. rename a slot in `rack_definitions` without corresponding modification in `sample_changer`
* Start the sample changer via the IOC test framework
* Confirm an error message appears on the GUI (assuming you have https://github.com/ISISComputingGroup/ibex_gui/pull/1377)
* Fix the error in the xml and reload the config, confirm error goes away
* Confirm errors are displayed when an invalid rack is selected 
* Confirm error box disappears when no errors exist