### PR TITLE
Ticket #7385: Fix some memory management

### DIFF
--- a/sampleChangerApp/src/sampleChanger.cpp
+++ b/sampleChangerApp/src/sampleChanger.cpp
@@ -81,7 +81,7 @@ asynStatus sampleChanger::writeOctet(asynUser *pasynUser, const char *value, siz
 
         current_errors[function] = c.errors();
         
-        *nActual = strnlen(value, 100); // return the number of characters actually written
+        *nActual = strnlen(value, maxChars); // return the number of characters actually written
     }
     else if (function == P_set_slot)
     {
@@ -99,14 +99,14 @@ asynStatus sampleChanger::writeOctet(asynUser *pasynUser, const char *value, siz
                 m_selectedSlot = newRack;
             }
             else {
-                sprintf_s(error, size_of_buffer, "%s:%s: setting slot=%s not possible (does not exist). Keeping old rack (%s)\n", driverName, functionName, newRack.c_str(), m_selectedSlot.c_str());
+                epicsSnprintf(error, size_of_buffer, "%s:%s: setting slot=%s not possible (does not exist). Keeping old rack (%s)\n", driverName, functionName, newRack.c_str(), m_selectedSlot.c_str());
                 asynPrint(pasynUser, ASYN_TRACE_ERROR, error);
                 current_errors[function] = error;
                 status = asynError;
             }
-
-            *nActual = strnlen(value, maxChars); // return the number of characters actually written
         }
+
+        *nActual = strnlen(value, maxChars); // return the number of characters actually written
     }
     else if (function == P_set_posn)
     {

--- a/sampleChangerApp/src/sampleChanger.cpp
+++ b/sampleChangerApp/src/sampleChanger.cpp
@@ -69,7 +69,9 @@ asynStatus sampleChanger::writeOctet(asynUser *pasynUser, const char *value, siz
     const char *paramName = NULL;
     getParamName(function, &paramName); // Get the name of the parameter
 
-    char error[100];
+    // Assign decent amount of buffer space to avoid memory overflow
+    const size_t size_of_buffer = 1000;
+    char error[size_of_buffer];
     current_errors[function] = "";
 
     if (function == P_recalc) 
@@ -79,7 +81,7 @@ asynStatus sampleChanger::writeOctet(asynUser *pasynUser, const char *value, siz
 
         current_errors[function] = c.errors();
         
-        *nActual = strlen(value); // return the number of characters actually written
+        *nActual = strnlen(value, 100); // return the number of characters actually written
     }
     else if (function == P_set_slot)
     {
@@ -97,7 +99,7 @@ asynStatus sampleChanger::writeOctet(asynUser *pasynUser, const char *value, siz
                 m_selectedSlot = newRack;
             }
             else {
-                sprintf(error, "%s:%s: setting slot=%s not possible (does not exist). Keeping old rack (%s)\n", driverName, functionName, newRack.c_str(), m_selectedSlot.c_str());
+                sprintf_s(error, size_of_buffer, "%s:%s: setting slot=%s not possible (does not exist). Keeping old rack (%s)\n", driverName, functionName, newRack.c_str(), m_selectedSlot.c_str());
                 asynPrint(pasynUser, ASYN_TRACE_ERROR, error);
                 current_errors[function] = error;
                 status = asynError;

--- a/sampleChangerApp/src/sampleChanger.h
+++ b/sampleChangerApp/src/sampleChanger.h
@@ -2,6 +2,7 @@
 #define SAMPLECHANGER_H
  
 #include <string>
+#include <inttypes.h>
 
 #include "asynPortDriver.h"
 #include "converter.h"
@@ -32,8 +33,8 @@ private:
      */
     std::string m_fileName;
     std::string m_selectedSlot;
-    int m_dims;
-    std::map <int, std::string> current_errors;
+    int32_t m_dims;
+    std::map <int32_t, std::string> current_errors;
 
     int P_recalc; // string
     int P_errors; // string

--- a/sampleChangerApp/src/sampleChanger.h
+++ b/sampleChangerApp/src/sampleChanger.h
@@ -2,7 +2,6 @@
 #define SAMPLECHANGER_H
  
 #include <string>
-#include <inttypes.h>
 
 #include "asynPortDriver.h"
 #include "converter.h"


### PR DESCRIPTION
[Ticket #7385](https://github.com/ISISComputingGroup/IBEX/issues/7385)

Found an issue in the `samplechanger` test suite with the IOC crashing on a 32-bit build. 
This was caused by `error` having a buffer size which was smaller than the amount of data assigned to it, so was causing some overflow issues in memory. Have made the buffer larger and used `sprint_fs` to further prevent attempting to overwrite non-allocated memory.